### PR TITLE
Use last known google code sdk

### DIFF
--- a/gui/FirstTimeWizard.cpp
+++ b/gui/FirstTimeWizard.cpp
@@ -102,7 +102,7 @@ FirstTimeWizard::FirstTimeWizard(QWidget *parent)
     projectLabel->setText(projectLabel->text().arg(PROJECT_NAME).arg(PROJECT_AUTHORS));
     urlLabel->setText(urlLabel->text().arg(PROJECT_URL));
 
-    url = "http://arduino.googlecode.com/files/arduino-" ARDUINO_SDK_VERSION_NAME;
+    url = "http://downloads.arduino.cc/arduino-" ARDUINO_SDK_VERSION_NAME;
 
     // set up the download page
 #if defined(Q_OS_WIN32) || defined(Q_OS_WIN64) // Windows


### PR DESCRIPTION
google code does not have arduino 1.0.6, Just fix that

After migration to github, you can obtain new versions simply

```
$ git clone https://github.com/arduino/Arduino
$ cd build
$ git checkout <tag> #e.g 1.0.5 or 1.6.6
$ ant dist #here prompt for a version, maybe a patch can use the default value
```

https://github.com/arduino/Arduino/blob/1.0.6/build/build.xml#L47

New version would be on 

```
build/<os>/arduino-<version>-<system>.tar.xz #e.g build/linux/arduino-1.6.6-linux64.tar.xz
```

I now this is a discontinued project, just want to mention if somebody wants to investigate code and stuck on sdk download, the misterious part for this project. 
